### PR TITLE
Make variables universal instead of global

### DIFF
--- a/functions/__proxy.set.fish
+++ b/functions/__proxy.set.fish
@@ -9,7 +9,7 @@ function __proxy.set -a proxy \
     if test $proxy = '-e'
       set -e $envar
     else
-      set -gx $envar $proxy
+      set -Ux $envar $proxy
     end
   end
 end


### PR DESCRIPTION
I think proxy variables should be universal instead of global, since this is usually a machine-wide setting.